### PR TITLE
Add make target to create cdn-route service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+.PHONY: create-cdn-route-service
+create-cdn-route-service:
+	$(if ${DOMAIN},,$(error Must specify DOMAIN))
+	cf create-service cdn-route cdn-route router_cdn -c '{"headers": ["*"], "domain": "www.${DOMAIN},api.${DOMAIN},search-api.${DOMAIN},assets.${DOMAIN}"}'
+
 .PHONY: docker-build
 docker-build:
 	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))


### PR DESCRIPTION
Should be run once on each PaaS environment to provision the
CloudFront service.