### PR TITLE
Use newly named `router-nginx` log group name

### DIFF
--- a/awslogs/awslogs.conf
+++ b/awslogs/awslogs.conf
@@ -3,6 +3,6 @@ state_file = /var/log/awslogs-state
 
 [nginx-access-logs]
 file = /var/log/digitalmarketplace/nginx_access.log
-log_group_name = {DM_ENVIRONMENT}-nginx-json
+log_group_name = {DM_ENVIRONMENT}-router-nginx
 log_stream_name = {hostname}
 datetime_format = %d/%b/%Y:%H:%M:%S %z


### PR DESCRIPTION
We have renamed our log group from `nginx-json` to `router-json`
and now point our logs to the new group.