### PR TITLE
Drop Amazon Cloudfront Request ID header

### DIFF
--- a/templates/_macros.j2
+++ b/templates/_macros.j2
@@ -11,6 +11,7 @@ proxy_set_header X-Forwarded-Proto https;
 proxy_set_header X-Forwarded-Host "$http_host";
 
 proxy_set_header DM-Request-ID "";
+proxy_set_header X-Amz-Cf-Id "";
 
 # drop headers returned by the app server that shouldn't be forwarded to the client
 proxy_hide_header "Strict-Transport-Security";


### PR DESCRIPTION
We don't nginx to pass this header on to later apps so instead
our apps will generate their own request ID instead of taking
the CloudFront one.