### PR TITLE
Nginx rate limiting

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,6 +47,9 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
+    # Basic rate limiting
+    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=10r/s;
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,19 @@ events {
     worker_connections 1024;
 }
 
+# Don't apply rate limiting to whitelisted IPs
+geo $limit {
+    default 1;
+    {% for admin_ip in admin_user_ips.split(",") %}
+    {{ admin_ip }} 0;
+    {% endfor %}
+}
+
+map $limit $limit_key {
+    0 "";
+    1 $binary_remote_addr;
+}
+
 http {
     # Set DNS resolver address
     resolver {{ resolver_ip }} valid=300s;
@@ -48,7 +61,7 @@ http {
     client_max_body_size 40m;
 
     # Basic rate limiting
-    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=10r/s;
+    limit_req_zone $limit_key zone=dm_limit:10m rate=10r/s;
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -12,8 +12,8 @@ events {
 # Don't apply rate limiting to whitelisted IPs
 geo $limit {
     default 1;
-    {% for admin_ip in admin_user_ips.split(",") %}
-    {{ admin_ip }} 0;
+    {% for dev_user_ip in dev_user_ips.split(",") %}
+    {{ dev_user_ip }} 0;
     {% endfor %}
 }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -60,8 +60,9 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
-    # Basic rate limiting
+    # Basic rate limiting (return 429 Too Many Requests instead of default 503)
     limit_req_zone $limit_key zone=dm_limit:10m rate=10r/s;
+    limit_req_status 429;
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -10,6 +10,9 @@ server {
 
     set $frontend_url "{{ frontend_url }}";
 
+    # Basic rate limiting
+    limit_req zone=dm_limit burst=20 nodelay;
+
     location /robots.txt {
         alias {{ static_files_root }}/robots_www.txt;
     }


### PR DESCRIPTION
We've had intermittent issues where an IP has scraped the site (the most recent being ~2 million hits in 2 days or 700 requests per second), increasing our log size beyond the accepted limit.

Blocking each IP isn't scalable, but instead we can rate limit a single IP to 10 requests per second. This can be increased later if it isn't sufficient.

As per the [nginx docs' recommendation](https://www.nginx.com/blog/rate-limiting-nginx/), I've included `burst` and `nodelay` options:
- `burst=20`: how many requests a client can make in excess of the rate specified by the zone (i.e. each extra request, up to 20 requests, would be queued and processed after 100ms). The 21st request would return a 503 error.
- `nodelay`: alters the above slightly in that the requests in the queue are processed immediately, but each queue slot still only frees up after 100ms.

**Reviewers**: I'm not very familiar with the router app so please check these two lines are in the right place. Thanks!