### PR TITLE
nginx: add `epochTime` to `log_format`

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -57,6 +57,7 @@ http {
                            ' "remoteHost": "$remote_addr", '
                            ' "user": "$remote_user", '
                            ' "time": "$time_local", '
+                           ' "epochTime": "$msec", '
                            ' "request": "$request", '
                            ' "status": $status, '
                            ' "size": $body_bytes_sent, '


### PR DESCRIPTION
...in the hopes we can retrieve the fractional seconds with future work.

See https://github.com/alphagov/digitalmarketplace-docker-base/pull/22 for equivalent in that repo.