### PR TITLE
nginx: unquote epochTime to ensure it's interpreted as a number

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -57,7 +57,7 @@ http {
                            ' "remoteHost": "$remote_addr", '
                            ' "user": "$remote_user", '
                            ' "time": "$time_local", '
-                           ' "epochTime": "$msec", '
+                           ' "epochTime": $msec, '
                            ' "request": "$request", '
                            ' "status": $status, '
                            ' "size": $body_bytes_sent, '


### PR DESCRIPTION
Little bit of an oops here.