### PR TITLE
Adds README info about the router app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # Digital Marketplace PaaS Router
 
-This is an Nginx application which acts as a proxy for all Digital Marketplace PaaS applications and provides an authentication layer.
+This is an Nginx application which acts as a proxy for all Digital Marketplace PaaS applications.
+
+Requests are routed to the correct location based on the hostname:
+
+| Hostname | Destination app |
+| :--- | :--- |
+| `api.*` | API |
+| `search-api.*` | Search API |
+| `www.*` | Front end apps |
+| `assets.*` | S3 resources (or the front end apps, depending on the path) |
 
 The router app also handles:
-
-- IP restrictions for admin pages
-- robots.txt
-- rate limiting
-- 'maintenance' mode (routing all requests to a static page)
-- gzip settings
+- Forwarding request headers (and adding any required headers for the app, e.g. Authorization)
+- IP restrictions for `/admin` pages
+- Serving the `robots.txt` static page
+- Rate limiting
+- 'Maintenance' mode (routing all requests to a static page)
+- `gzip` settings for CSS and Javascript files
 
 
 ## Testing nginx changes locally

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This is an Nginx application which acts as a proxy for all Digital Marketplace PaaS applications and provides an authentication layer.
 
+The router app also handles:
+
+- IP restrictions for admin pages
+- robots.txt
+- rate limiting
+- 'maintenance' mode (routing all requests to a static page)
+- gzip settings
+
+
 ## Testing nginx changes locally
 
 To test changes to the nginx configuration, use Docker and `docker-compose` to build a new router image.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ Requests are routed to the correct location based on the hostname:
 | `assets.*` | S3 resources (or the front end apps, depending on the path) |
 
 The router app also handles:
-- Forwarding request headers (and adding any required headers for the app, e.g. Authorization)
+- Forwarding request headers
+- Adding the Basic Auth header to frontend app requests (these apps' URLs cannot be accessed directly,
+and must go via the router app)
 - IP restrictions for `/admin` pages
 - Serving the `robots.txt` static page
 - Rate limiting
 - 'Maintenance' mode (routing all requests to a static page)
 - `gzip` settings for CSS and Javascript files
 
+The app-level nginx configurations can be found in the [Docker base repo](https://github.com/alphagov/digitalmarketplace-docker-base).
 
 ## Testing nginx changes locally
 


### PR DESCRIPTION
Adds a little more description about the scope of the router app. 

Notable by its absence from the list: caching 😿. I think we rely on PaaS's CDN defaults for client side caching headers - can anyone confirm if we have server side caching on PaaS or anywhere else?