### PR TITLE
Rewrite host when assets 404

### DIFF
--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -68,6 +68,10 @@ server {
     location /404 {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
+        if ($host ~* ^assets\.(.*)) {
+            set $host_with_www www.$1;
+            rewrite ^(.*)$ $scheme://$host_with_www$request_uri;
+        }
         proxy_pass $frontend_url;
     }
 


### PR DESCRIPTION
When a user received a 404 from our assets, nginx would intercept and
proxy the request to the frontend, specifically the buyer frontend.

The frontend apps generate links using `request.url_root`. As the
original request was for the assets subdomain, all links on the
rendered page are also for the assets subdomain. This means that things
like links to the homepage or the login page would break.

By rewriting the host in nginx to replace `assets` with `www` we can fix
this.

The if block allows us to use a regex capture group on the host variable
which can then be used to build the new host variable. This is necessary
to allow this to work across the environments (the host name will change
so needs to dynamically assigned rather than hardcoding).