### PR TITLE
Deactivate rate limiting for load testing

### DIFF
--- a/templates/www.j2
+++ b/templates/www.j2
@@ -12,7 +12,7 @@ server {
     set $frontend_url "{{ frontend_url }}";
 
     # Basic rate limiting
-    limit_req zone=dm_limit burst=40 nodelay;
+    # limit_req zone=dm_limit burst=40 nodelay;
     error_page 429 @too_many_requests;
     location @too_many_requests {
         add_header Retry-After 300 always;


### PR DESCRIPTION
The load tests were triggering the rate limiting. Whilst this isn't a bad thing, it's also not realistic as all traffic is coming from 1 ip address.