### PR TITLE
Makefile task for testing nginx config using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+sudo: false
+python:
+  - "3.6"
+services:
+  - docker
+script:
+  - make test-nginx
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+SHELL := /bin/bash
+
+TEST_CONTAINER_NAME := digitalmarketplace_test_router
+TEST_IMAGE_NAME := digitalmarketplace/test-router
+
 .PHONY: create-cdn-route-service
 create-cdn-route-service:
 	$(if ${DOMAIN},,$(error Must specify DOMAIN))
@@ -9,6 +14,40 @@ docker-build:
 	@echo "Building a docker image for ${RELEASE_NAME}..."
 	docker build -t digitalmarketplace/router .
 	docker tag digitalmarketplace/router digitalmarketplace/router:${RELEASE_NAME}
+
+.PHONY: test-nginx
+test-nginx:
+	@echo "Building a docker image for the current directory..."
+	docker build -t ${TEST_IMAGE_NAME} .
+
+	@echo "Remove any existing '${TEST_CONTAINER_NAME}' containers if present"
+	@docker rm -f ${TEST_CONTAINER_NAME} || true
+
+	@echo "Starting a docker container for '${TEST_IMAGE_NAME}'..."
+	@docker run \
+		-e DM_USER_IPS=172.0.0.0 \
+		-e DM_DEV_USER_IPS=172.0.0.0 \
+		-e DM_ADMIN_USER_IPS=172.0.0.0 \
+		-e DM_FRONTEND_URL=http://frontend-apps \
+		-e DM_API_URL=http://localhost:5000 \
+		-e DM_SEARCH_API_URL=http://localhost:5001 \
+		-e DM_APP_AUTH=12345678 \
+		-e DM_DOCUMENTS_S3_URL=https://test-s3 \
+		-e DM_G7_DRAFT_DOCUMENTS_S3_URL=https://test-s3 \
+		-e DM_AGREEMENTS_S3_URL=https://test-s3 \
+		-e DM_COMMUNICATIONS_S3_URL=https://test-s3 \
+		-e DM_SUBMISSIONS_S3_URL=https://test-s3 \
+		--name ${TEST_CONTAINER_NAME} \
+		-p 8080:8080 \
+		-d -t ${TEST_IMAGE_NAME}
+	@docker exec -d ${TEST_CONTAINER_NAME} supervisord --configuration /etc/supervisord.conf
+	@echo "## Waiting for nginx to start..."
+
+	@docker exec ${TEST_CONTAINER_NAME} sh -c "until (service nginx status >dev/null || ! nginx -t > /dev/null 2>&1); do sleep 1; done && nginx -t"
+
+	@echo "## Tearing down test container and image"
+	@docker rm -f ${TEST_CONTAINER_NAME}
+	@docker image rm ${TEST_IMAGE_NAME}
 
 .PHONY: docker-push
 docker-push:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,30 @@ The app-level nginx configurations can be found in the [Docker base repo](https:
 
 ## Testing nginx changes locally
 
-To test changes to the nginx configuration, use Docker and `docker-compose` to build a new router image.
+There are two ways to test changes to the nginx configuration:
+
+### make test-nginx
+
+Assuming you have [Docker](https://docs.docker.com/engine/installation/) installed:
+
+Running `make test-nginx` does the following:
+- builds a new Docker image from your local repo (using the `Dockerfile`)
+- starts running a container based on that image, using dummy environment variables
+- starts up nginx inside the image (this takes a few seconds)
+- runs `nginx -t` to check the config:
+
+        nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
+        nginx: configuration file /etc/nginx/nginx.conf test is successful
+
+If the config test is successful, the container is stopped and removed. If there is a failure, the container
+is preserved for investigation.
+
+You can use `docker exec -i -t digitalmarketplacerouter_test /bin/bash` to look inside the container.
+
+
+### docker-compose
+
+This method uses Docker and `docker-compose` to build the router image.
 
 Assuming you have [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed:
 


### PR DESCRIPTION
Testing nginx changes locally is a bit annoying, especially if you just want to check for syntax errors. 

`make test-nginx` will spin up a new Docker container from your local changes and attempt to build and run nginx, outputting any config errors (from `nginx -t`). 

If the the config test is successful, the container is stopped and removed (ready for the next run). If there is a failure, the container is not removed and you can go in and investigate what's happened.

You can still follow the `docker-compose` instructions if you want to check more complex configuration/test different env vars/etc.