### PR TITLE
Strip sampling headers

### DIFF
--- a/templates/_macros.j2
+++ b/templates/_macros.j2
@@ -1,3 +1,24 @@
+# `prepare_trace_header_values` should be injected into every `server` block.
+# It disables debug/trace headers if the remote address is an external (non-GDS/non-developer) IP.
+# The variables here are initialized in the root `http` context.
+
+{% macro prepare_trace_header_values() %}
+# Save the values of the X-B3-Sampled and X-B3-Flags headers so the variables are in scope for all subsequent blocks
+set $x_b3_sampled_value $http_x_b3_sampled;
+set $x_b3_flags_value $http_x_b3_flags;
+
+if ($strip_trace_headers) {
+  set $x_b3_sampled_value 0;
+  set $x_b3_flags_value 0;
+}
+{% endmacro %}
+
+
+# Any uses of `proxy_headers` must have a use of `prepare_trace_header_values` somewhere up the chain to properly
+# set the required variables for stripping debug/sampling headers.
+# We don't inline `prepare_trace_header_values` to this macro as `proxy_headers` might get used inside an `location`
+# context, wherein we try to avoid using `if` directives:
+# https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
 {% macro proxy_headers() %}
 
 proxy_redirect http:// https://;
@@ -12,6 +33,9 @@ proxy_set_header X-Forwarded-Host "$http_host";
 
 proxy_set_header DM-Request-ID "";
 proxy_set_header X-Amz-Cf-Id "";
+
+proxy_set_header X-B3-Sampled $x_b3_sampled_value;
+proxy_set_header X-B3-Flags $x_b3_flags_value;
 
 # drop headers returned by the app server that shouldn't be forwarded to the client
 proxy_hide_header "Strict-Transport-Security";

--- a/templates/api.j2
+++ b/templates/api.j2
@@ -1,4 +1,5 @@
 {% from "_macros.j2" import proxy_headers with context %}
+{% from "_macros.j2" import prepare_trace_header_values with context %}
 server {
     listen 80;
     server_name api.*;
@@ -9,6 +10,8 @@ server {
     allow {{ dev_ip }};
     {% endfor %}
     deny all;
+
+    {{ prepare_trace_header_values() }}
 
     location / {
         {{ proxy_headers() }}
@@ -24,6 +27,8 @@ server {
     allow {{ dev_ip }};
     {% endfor %}
     deny all;
+
+    {{ prepare_trace_header_values() }}
 
     set $search_api_url "{{ search_api_url }}";
 

--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -1,4 +1,5 @@
 {% from "_macros.j2" import proxy_headers with context %}
+{% from "_macros.j2" import prepare_trace_header_values with context %}
 server {
     listen 80;
     server_name assets.*;
@@ -15,6 +16,8 @@ server {
     set $agreements_s3_url "{{ agreements_s3_url }}";
     set $communications_s3_url "{{ communications_s3_url }}";
     set $submissions_s3_url "{{ submissions_s3_url }}";
+
+    {{ prepare_trace_header_values() }}
 
     {{ proxy_headers() }}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -58,6 +58,16 @@ http {
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;
 
+    # Set variable indicating to strip out trace/debug headers coming from external (non-GDS/non-dev) IPs
+
+    map $remote_addr $strip_trace_headers {
+      default 1;
+
+{% for dev_ip in dev_user_ips.split(",") %}
+      {{ dev_ip.split('/')[0] }} 0;
+{% endfor %}
+    }
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -1,4 +1,5 @@
 {% from "_macros.j2" import proxy_headers with context %}
+{% from "_macros.j2" import prepare_trace_header_values with context %}
 
 upstream static_429_error {
     server localhost:10823;
@@ -28,6 +29,8 @@ server {
         proxy_method GET;
         proxy_pass http://static_429_error;
     }
+
+    {{ prepare_trace_header_values() }}
 
     location /robots.txt {
         rewrite ^(.*)$ /robots_www.txt break;


### PR DESCRIPTION
 ## Summary
We only want to allow sampling/debugging of requests from internal
(developer/GDS) IPs. If the request is from an external IP (i.e. a
normal user), strip out the two headers that indicate internal
debugging: X-B3-SAMPLED and X-B3-FLAGS.