### PR TITLE
Allow external access to API callback route

### DIFF
--- a/templates/api.j2
+++ b/templates/api.j2
@@ -6,14 +6,19 @@ server {
 
     set $api_url "{{ api_url }}";
 
-    {% for dev_ip in dev_user_ips.split(",") %}
-    allow {{ dev_ip }};
-    {% endfor %}
-    deny all;
-
     {{ prepare_trace_header_values() }}
 
     location / {
+        {% for dev_ip in dev_user_ips.split(",") %}
+        allow {{ dev_ip }};
+        {% endfor %}
+        deny all;
+
+        {{ proxy_headers() }}
+        proxy_pass $api_url;
+    }
+
+    location /callbacks {
         {{ proxy_headers() }}
         proxy_pass $api_url;
     }


### PR DESCRIPTION
 ## Summary
We want Notify to send us callbacks with information on the
success/failure of notification delivery so that we can act on the
outcome. We'll add a blueprint to the API attached at `/callbacks`, but
we need to open up those routes to external access so that the Notify
servers can post to it.

We will implement separate authentication on these routes for Notify to
use.

 ## Ticket
https://trello.com/c/vOAUDwnL/446