### PR TITLE
nginx logging: switch to/output more zipkin header-derived information

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -74,7 +74,7 @@ http {
     # Logging Settings
 
     log_format access_json '{"logType": "nginx-access", '
-                           ' "requestId": "$upstream_http_dm_request_id", '
+                           ' "requestId": "$http_x_b3_traceid", '
                            ' "remoteHost": "$remote_addr", '
                            ' "user": "$remote_user", '
                            ' "time": "$time_local", '

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -75,6 +75,10 @@ http {
 
     log_format access_json '{"logType": "nginx-access", '
                            ' "requestId": "$http_x_b3_traceid", '
+                           ' "spanId": "$http_x_b3_spanid", '
+                           ' "parentSpanId": "$http_x_b3_parentspanid", '
+                           ' "isSampled": "$http_x_b3_sampled", '
+                           ' "debugFlag": "$http_x_b3_flags", '
                            ' "remoteHost": "$remote_addr", '
                            ' "user": "$remote_user", '
                            ' "time": "$time_local", '


### PR DESCRIPTION
This is analogous to https://github.com/alphagov/digitalmarketplace-docker-base/pull/32

Using `X-B3-TraceId` request header instead of waiting for `DM-RequestId` response header (which we may or may not get back depending on whether the request actually reached an app) should more reliably give us an id.

This PR also adds the other zipkin headers to our log output.