### PR TITLE
tracing: enable sampling mode for 1 in 256 requests, "randomly" driven by traceid

### DIFF
--- a/templates/_macros.j2
+++ b/templates/_macros.j2
@@ -11,6 +11,11 @@ if ($strip_trace_headers) {
   set $x_b3_sampled_value 0;
   set $x_b3_flags_value 0;
 }
+
+# if "sampled" mode hasn't already been enabled, allow the result of $random_sample to make the final decision
+if ($x_b3_sampled_value = 0) {
+  set $x_b3_sampled_value $random_sample;
+}
 {% endmacro %}
 
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -68,6 +68,18 @@ http {
 {% endfor %}
     }
 
+    # nginx isn't very good at randomness, so use the value of the traceid header to drive our "random sampling"
+    # decision as it should have been chosen randomly enough upstream
+    map $http_x_b3_traceid $random_sample {
+        default 0;
+
+        # if the second and fourth nibbles of the traceid are 'f', indicate that sampling should be enabled for this
+        # request. should result in one in 256 requests being sampled. why two arbitrarily chosen nibbles? we don't
+        # want this selection to accidentally correlate with anything else that may be using traceid for a stochastic
+        # decision, and it's less likely anything else will have chosen exactly these nibbles
+        ~*^.f.f.* 1;
+    }
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 


### PR DESCRIPTION
I think I've said enough about the implementation in the actual comments.

The purpose of this is to be able to gather profiling information

a) historically, to be able to look at aggregate statistics
b) during problematic performance spikes when we're not on-hand to probe them ourselves

without overwhelming ourselves with log volume. I've started off with 1/256 mostly because it's very straightforward to express in a regex, but that's tunable.