### PR TITLE
random sampling: also consider empty strings as "unset" values of $x_b3_sampled_value

### DIFF
--- a/templates/_macros.j2
+++ b/templates/_macros.j2
@@ -12,8 +12,9 @@ if ($strip_trace_headers) {
   set $x_b3_flags_value 0;
 }
 
-# if "sampled" mode hasn't already been enabled, allow the result of $random_sample to make the final decision
-if ($x_b3_sampled_value = 0) {
+# if "sampled" mode hasn't already been enabled ($x_b3_sampled_value is empty or 0), allow the result of $random_sample
+# to become the final decision
+if ($x_b3_sampled_value ~ "^0?$") {
   set $x_b3_sampled_value $random_sample;
 }
 {% endmacro %}


### PR DESCRIPTION
So yeah @katstevens was right when she spotted my logical error and I :hankey: :hankey: ed her. `$x_b3_sampled_value` will only be set to `0` if explicitly set by the requester or scrubbed by `$strip_trace_headers`. Otherwise it will be the empty string, which we also want to consider for random sampling.