### PR TITLE
Add reports S3 bucket to router nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test-nginx:
 		-e DM_G7_DRAFT_DOCUMENTS_S3_URL=https://test-s3 \
 		-e DM_AGREEMENTS_S3_URL=https://test-s3 \
 		-e DM_COMMUNICATIONS_S3_URL=https://test-s3 \
+		-e DM_REPORTS_S3_URL=https://test-s3 \
 		-e DM_SUBMISSIONS_S3_URL=https://test-s3 \
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -20,6 +20,7 @@ services:
       - DM_G7_DRAFT_DOCUMENTS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
       - DM_AGREEMENTS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
       - DM_COMMUNICATIONS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
+      - DM_REPORTS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
       - DM_SUBMISSIONS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
     command: >
       sed -i -e "s/proxy_redirect/# proxy_redirect/g" /app/templates/_macros.j2 &&

--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -15,6 +15,7 @@ server {
     set $frontend_url "{{ frontend_url }}";
     set $agreements_s3_url "{{ agreements_s3_url }}";
     set $communications_s3_url "{{ communications_s3_url }}";
+    set $reports_s3_url "{{ reports_s3_url }}";
     set $submissions_s3_url "{{ submissions_s3_url }}";
 
     {{ prepare_trace_header_values() }}
@@ -60,6 +61,12 @@ server {
         proxy_intercept_errors on;
 
         proxy_pass $submissions_s3_url;
+    }
+
+    location ~ ^/[^/]+/reports/ {
+        proxy_intercept_errors on;
+
+        proxy_pass $reports_s3_url;
     }
 
     location /g-cloud-7 {


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

Create a proxy URL for the new S3 bucket under our `assets.*` pattern.

Reliant on https://github.com/alphagov/digitalmarketplace-credentials/pull/151 being merged first.