### PR TITLE
Update nginx to latest stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13
+FROM nginx:1.14
 
 ENV APP_DIR /app
 


### PR DESCRIPTION
Updates nginx to latest version of nginx 1.14 (currently 1.14.1). Nginx 1.14 is the stable branch, there is also a mainline branch, 1.15.

Closes https://trello.com/c/zBUjwx0o

Nginx [changelog](https://nginx.org/en/CHANGES-1.14) does not indicate any breaking changes, and `make test-nginx` reported no issues with the configuration file.