### PR TITLE
add merge_slashes setting to configuration to merge multiple consecutive slashes to one

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -28,6 +28,9 @@ http {
     # Ignore trusted IPs in X-Forwarded-For
     real_ip_recursive on;
 
+    # merge multiple consecutive slashes to one
+    merge_slashes on;
+
     # a few good practice security headers
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;


### PR DESCRIPTION
https://trello.com/c/ZniGEuve/256-flask-handling-of-double-forward-slashes

I'm currently unable to actually *try* this, but it **should** fix the above ticket. I've mentioned in that ticket that in my mind, this kind of thing is usually better dealt with through *redirecting to* a "fixed" url rather than "normalizing", but this does seem to be the path of least resistance.

What do others think? 