### PR TITLE
proxy_pass: make sure, in most cases, target url is specified with a trailing slash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,17 +36,17 @@ test-nginx:
 		-e DM_USER_IPS=172.0.0.0 \
 		-e DM_DEV_USER_IPS=172.0.0.0 \
 		-e DM_ADMIN_USER_IPS=172.0.0.0 \
-		-e DM_FRONTEND_URL=http://frontend-apps \
+		-e DM_FRONTEND_URL=http://example.net \
 		-e DM_API_URL=http://localhost:5000 \
 		-e DM_SEARCH_API_URL=http://localhost:5001 \
 		-e DM_ANTIVIRUS_API_URL=http://localhost:5008 \
 		-e DM_APP_AUTH=12345678 \
-		-e DM_DOCUMENTS_S3_URL=https://test-s3 \
-		-e DM_G7_DRAFT_DOCUMENTS_S3_URL=https://test-s3 \
-		-e DM_AGREEMENTS_S3_URL=https://test-s3 \
-		-e DM_COMMUNICATIONS_S3_URL=https://test-s3 \
-		-e DM_REPORTS_S3_URL=https://test-s3 \
-		-e DM_SUBMISSIONS_S3_URL=https://test-s3 \
+		-e DM_DOCUMENTS_S3_URL=https://example.com \
+		-e DM_G7_DRAFT_DOCUMENTS_S3_URL=https://example.com \
+		-e DM_AGREEMENTS_S3_URL=https://example.com \
+		-e DM_COMMUNICATIONS_S3_URL=https://example.com \
+		-e DM_REPORTS_S3_URL=https://example.com \
+		-e DM_SUBMISSIONS_S3_URL=https://example.com \
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \
 		-d -t ${TEST_IMAGE_NAME}

--- a/scripts/render-template.py
+++ b/scripts/render-template.py
@@ -12,12 +12,23 @@ def load_file(path):
         return f.read()
 
 
+def ensure_trailing_slash(value):
+    """
+    jinja filter to add a trailing slash to value if not already present - particularly useful when passing an url
+    to the proxy_pass directive which behaves differently depending on whether a target address has an url "path" part
+    """
+    value = str(value)
+    return value if value.endswith("/") else value + "/"
+
+
 def template_string(string, variables, templates_path):
     jinja_env = jinja2.Environment(
         trim_blocks=True,
         undefined=StrictUndefined,
         loader=jinja2.FileSystemLoader(templates_path)
     )
+
+    jinja_env.filters["ensure_trailing_slash"] = ensure_trailing_slash
 
     try:
         template = jinja_env.from_string(string)

--- a/templates/api.j2
+++ b/templates/api.j2
@@ -4,8 +4,6 @@ server {
     listen 80;
     server_name api.*;
 
-    set $api_url "{{ api_url }}";
-
     {{ prepare_trace_header_values() }}
 
     location / {
@@ -15,12 +13,12 @@ server {
         deny all;
 
         {{ proxy_headers() }}
-        proxy_pass $api_url;
+        proxy_pass {{ api_url|ensure_trailing_slash }};
     }
 
     location /callbacks {
         {{ proxy_headers() }}
-        proxy_pass $api_url;
+        proxy_pass {{ api_url|ensure_trailing_slash }};
     }
 }
 
@@ -35,19 +33,15 @@ server {
 
     {{ prepare_trace_header_values() }}
 
-    set $search_api_url "{{ search_api_url }}";
-
     location / {
         {{ proxy_headers() }}
-        proxy_pass $search_api_url;
+        proxy_pass {{ search_api_url|ensure_trailing_slash }};
     }
 }
 
 server {
     listen 80;
     server_name antivirus-api.*;
-
-    set $antivirus_api_url "{{ antivirus_api_url }}";
 
     {{ prepare_trace_header_values() }}
 
@@ -58,11 +52,11 @@ server {
         deny all;
 
         {{ proxy_headers() }}
-        proxy_pass $antivirus_api_url;
+        proxy_pass {{ antivirus_api_url|ensure_trailing_slash }};
     }
 
     location /callbacks {
         {{ proxy_headers() }}
-        proxy_pass $antivirus_api_url;
+        proxy_pass {{ antivirus_api_url|ensure_trailing_slash }};
     }
 }

--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -10,14 +10,6 @@ server {
     {% endfor %}
     deny all;
 
-    set $documents_s3_url "{{ documents_s3_url }}";
-    set $g7_draft_documents_s3_url "{{ g7_draft_documents_s3_url }}";
-    set $frontend_url "{{ frontend_url }}";
-    set $agreements_s3_url "{{ agreements_s3_url }}";
-    set $communications_s3_url "{{ communications_s3_url }}";
-    set $reports_s3_url "{{ reports_s3_url }}";
-    set $submissions_s3_url "{{ submissions_s3_url }}";
-
     {{ prepare_trace_header_values() }}
 
     {{ proxy_headers() }}
@@ -29,59 +21,59 @@ server {
     location / {
         proxy_intercept_errors on;
 
-        proxy_pass $documents_s3_url;
+        proxy_pass {{ documents_s3_url }};
     }
 
     location ~ ^/[^/]+/documents/ {
         proxy_intercept_errors on;
 
-        proxy_pass $documents_s3_url;
+        proxy_pass {{ documents_s3_url }};
     }
 
     location ~ ^/[^/]+/agreements/ {
         proxy_intercept_errors on;
 
-        proxy_pass $agreements_s3_url;
+        proxy_pass {{ agreements_s3_url }};
     }
 
     # Hack to force g7 communications to the old bucket to preserve upload times
     location ^~ /g-cloud-7-updates/communications {
         proxy_intercept_errors on;
 
-        proxy_pass $g7_draft_documents_s3_url;
+        proxy_pass {{ g7_draft_documents_s3_url }};
     }
 
     location ~ ^/[^/]+/communications/ {
         proxy_intercept_errors on;
 
-        proxy_pass $communications_s3_url;
+        proxy_pass {{ communications_s3_url }};
     }
 
     location ~ ^/[^/]+/submissions/ {
         proxy_intercept_errors on;
 
-        proxy_pass $submissions_s3_url;
+        proxy_pass {{ submissions_s3_url }};
     }
 
     location ~ ^/[^/]+/reports/ {
         proxy_intercept_errors on;
 
-        proxy_pass $reports_s3_url;
+        proxy_pass {{ reports_s3_url }};
     }
 
     location /g-cloud-7 {
         proxy_intercept_errors on;
 
-        proxy_pass $g7_draft_documents_s3_url;
+        proxy_pass {{ g7_draft_documents_s3_url }};
     }
 
     location /404 {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
-        proxy_pass $frontend_url;
+        proxy_pass {{ frontend_url }};
     }
 
     location /static {
-        proxy_pass $frontend_url;
+        proxy_pass {{ frontend_url }};
     }
 }

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -15,8 +15,6 @@ server {
     {% endfor %}
     deny all;
 
-    set $frontend_url "{{ frontend_url }}";
-
     # Basic rate limiting
     limit_req zone=dm_limit burst=40 nodelay;
     limit_req zone=dm_post_limit burst=5;
@@ -40,7 +38,7 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass $frontend_url;
+        proxy_pass {{ frontend_url|ensure_trailing_slash }};
     }
 
     location /admin {
@@ -52,7 +50,7 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass $frontend_url;
+        proxy_pass {{ frontend_url|ensure_trailing_slash }};
     }
 }
 


### PR DESCRIPTION
https://trello.com/c/ZniGEuve

This ensures that the target is interpreted as a URI and so has the *normalized* path of the incoming request applied to it to generate the onwards path, notably having performed slash merging.

This does however mean that we can't use nginx "variables" for these target urls because those are too dynamic and opaque to nginx's configuration system for it to be able to make decisions about behaviour based on their values. fortunately we can of course still use jinja variables.

The idea with the `ensure_trailing_slash` filter is I didn't want to burden the vars file with those editing it needing to know about this specific necessity for there to be/not to be a trailing slash included in this variable. And other places using this variable might have other conflicting requirements for it.

If this works, I should add some functional tests to cover double-slashes etc. On that note, to what extent do our functional tests cover the correct operation of our asset routes?