### PR TITLE
322-move-metrics-to-metrics-and-expose

### DIFF
--- a/templates/www.j2
+++ b/templates/www.j2
@@ -34,6 +34,10 @@ server {
         rewrite ^(.*)$ /robots_www.txt break;
     }
 
+    location ~ /metrics$ {
+        deny all;
+    }
+
     location / {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";


### PR DESCRIPTION
Disallow access to metrics through public url
* Add rule to nginx denying access to any endpoint ending in /metrics from public urls