### PR TITLE
Hardcode metrics path restriction to Brief Responses FE

### DIFF
--- a/templates/www.j2
+++ b/templates/www.j2
@@ -34,7 +34,8 @@ server {
         rewrite ^(.*)$ /robots_www.txt break;
     }
 
-    location ~ /metrics$ {
+    # Block access to Brief Response FE metrics path
+    location /suppliers/opportunities/metrics {
         deny all;
     }
 


### PR DESCRIPTION
The original restriction was blocking one of the service questions on the Supplier FE.