### PR TITLE
[WIP] Trying out rate limit token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test-nginx:
 		-e DM_COMMUNICATIONS_S3_URL=https://example.com \
 		-e DM_REPORTS_S3_URL=https://example.com \
 		-e DM_SUBMISSIONS_S3_URL=https://example.com \
+		-e DM_RATE_LIMIT_TOKEN=myToken \
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \
 		-d -t ${TEST_IMAGE_NAME}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,13 +47,23 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
-    # Basic rate limiting (return 429 Too Many Requests instead of default 503)
+    # Rate limiting (return 429 Too Many Requests instead of default 503)
     # Requests are by default limited to 50 requests/second, POST requests to 2 requests/second
     # Both limits also include a small burst allowance for extra requests in quick succession.
-    map $request_method $post_remote_addr {
-      default      "";
-      POST         $binary_remote_addr;
+
+    # Bypass rate limiting with `Rate-Limit-Token` headers.
+    map $http_Rate_Limit_Token $limit_req {
+      default                $binary_remote_addr;
+      {{ rate_limit_token }} "";
     }
+
+    # Create another rate limiting zone that only limits POST requests (without a token header)
+    map "$http_Rate_Limit_Token:$request_method" $post_remote_addr {
+      default                       "";
+      {{ rate_limit_token }}:POST   "";
+      ~:POST$                       $binary_remote_addr;
+    }
+
     limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=50r/s;
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;


### PR DESCRIPTION
Based on the GOV.UK rate limit code: https://github.com/alphagov/govuk-puppet/blob/master/modules/router/templates/rate-limiting.conf.erb

This proof of concept looks for a `Rate-Limit-Token` header and skips rate limiting if the value matches the supplied env variable `DM_RATE_LIMIT_TOKEN`. I checked the template generation using `make nginx-test` and it looks ok (and passes `nginx -t`) but haven't yet tested the actual rate limit functionality due to local Docker port snafus. I thought I'd ask for some feedback first.

GOV.UK uses a list of tokens but for ease of template wrangling I've just used one.
One thing I haven't explored: what happens if the env var isn't set.

Thoughts? Any reason why we shouldn't do this?