### PR TITLE
592-504-errors-on-production-nginx-dns

### DIFF
--- a/templates/api.j2
+++ b/templates/api.j2
@@ -6,6 +6,7 @@ server {
 
     {{ prepare_trace_header_values() }}
 
+    set $api_url {{ api_url|urljoin("/") }};
     location / {
         {% for dev_ip in dev_user_ips.split(",") %}
         allow {{ dev_ip }};
@@ -13,12 +14,13 @@ server {
         deny all;
 
         {{ proxy_headers() }}
-        proxy_pass {{ api_url|urljoin("/") }};
+        proxy_pass $api_url;
     }
 
+    set $api_callbacks_url {{ api_url|urljoin("/callbacks") }};
     location /callbacks {
         {{ proxy_headers() }}
-        proxy_pass {{ api_url|urljoin("/callbacks") }};
+        proxy_pass $api_callbacks_url;
     }
 }
 
@@ -33,9 +35,10 @@ server {
 
     {{ prepare_trace_header_values() }}
 
+    set $search_api_url {{ search_api_url|urljoin("/") }};
     location / {
         {{ proxy_headers() }}
-        proxy_pass {{ search_api_url|urljoin("/") }};
+        proxy_pass $search_api_url;
     }
 }
 
@@ -45,6 +48,7 @@ server {
 
     {{ prepare_trace_header_values() }}
 
+    set $antivirus_api_url {{ antivirus_api_url|urljoin("/") }};
     location / {
         {% for dev_ip in dev_user_ips.split(",") %}
         allow {{ dev_ip }};
@@ -52,11 +56,12 @@ server {
         deny all;
 
         {{ proxy_headers() }}
-        proxy_pass {{ antivirus_api_url|urljoin("/") }};
+        proxy_pass $antivirus_api_url;
     }
 
+    set $antivirus_api_callbacks_url {{ antivirus_api_url|urljoin("/callbacks") }};
     location /callbacks {
         {{ proxy_headers() }}
-        proxy_pass {{ antivirus_api_url|urljoin("/callbacks") }};
+        proxy_pass $antivirus_api_callbacks_url;
     }
 }

--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -18,62 +18,69 @@ server {
         alias {{ static_files_root }}/robots_assets.txt;
     }
 
+    set $documents_s3_url {{ documents_s3_url }};
     location / {
         proxy_intercept_errors on;
 
-        proxy_pass {{ documents_s3_url }};
+        proxy_pass $documents_s3_url;
     }
 
     location ~ ^/[^/]+/documents/ {
         proxy_intercept_errors on;
 
-        proxy_pass {{ documents_s3_url }};
+        proxy_pass $documents_s3_url;
     }
 
+    set $agreements_s3_url {{ agreements_s3_url }};
     location ~ ^/[^/]+/agreements/ {
         proxy_intercept_errors on;
 
-        proxy_pass {{ agreements_s3_url }};
+        proxy_pass $agreements_s3_url;
     }
 
     # Hack to force g7 communications to the old bucket to preserve upload times
+    set $g7_draft_documents_s3_url {{ g7_draft_documents_s3_url }};
     location ^~ /g-cloud-7-updates/communications {
         proxy_intercept_errors on;
 
-        proxy_pass {{ g7_draft_documents_s3_url }};
+        proxy_pass $g7_draft_documents_s3_url;
     }
 
+    set $communications_s3_url {{ communications_s3_url }};
     location ~ ^/[^/]+/communications/ {
         proxy_intercept_errors on;
 
-        proxy_pass {{ communications_s3_url }};
+        proxy_pass $communications_s3_url;
     }
 
+    set $submissions_s3_url {{ submissions_s3_url }};
     location ~ ^/[^/]+/submissions/ {
         proxy_intercept_errors on;
 
-        proxy_pass {{ submissions_s3_url }};
+        proxy_pass $submissions_s3_url;
     }
 
+    set $reports_s3_url {{ reports_s3_url }};
     location ~ ^/[^/]+/reports/ {
         proxy_intercept_errors on;
 
-        proxy_pass {{ reports_s3_url }};
+        proxy_pass $reports_s3_url;
     }
 
     location /g-cloud-7 {
         proxy_intercept_errors on;
 
-        proxy_pass {{ g7_draft_documents_s3_url }};
+        proxy_pass  $g7_draft_documents_s3_url;
     }
 
+    set $frontend_url {{ frontend_url }};
     location /404 {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
-        proxy_pass {{ frontend_url }};
+        proxy_pass $frontend_url;
     }
 
     location /static {
-        proxy_pass {{ frontend_url }};
+        proxy_pass $frontend_url;
     }
 }

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -39,13 +39,14 @@ server {
         deny all;
     }
 
+    set $frontend_url {{ frontend_url|urljoin("/") }};
     location / {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
-
-        proxy_pass {{ frontend_url|urljoin("/") }};
+        proxy_pass $frontend_url;
     }
 
+    set $admin_frontend_url {{ frontend_url|urljoin("/admin") }};
     location /admin {
         {% for admin_ip in admin_user_ips.split(",") %}
         allow {{ admin_ip }};
@@ -55,7 +56,7 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass {{ frontend_url|urljoin("/admin") }};
+        proxy_pass $admin_frontend_url;
     }
 }
 


### PR DESCRIPTION
We need to define our urls as variables and pass these to proxy pass to ensure the dns lookup is periodically expired.
We have seen 504 errors when the ips of our s3 buckets are changed because the DNS resolution is never expired and always points to the ip looked up when the papp is started.

> domain names statically configured in config are only looked up once on startup (or configuration reload).
https://forum.nginx.org/read.php?2,215830,215832#msg-215832

> Setting proxy_pass to a variable forces re-resolution of the DNS names, because Nginx treats variables differently to static configuration
https://serverfault.com/a/593003

These variables must be set _outside_ the location block:
https://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p#comment875954_593003