### PR TITLE
592-504-errors-on-production-nginx-dns

### DIFF
--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -26,13 +26,13 @@ server {
     set $frontend_url {{ frontend_url }};
     set $static_files_root {{ static_files_root }};
 
-    location ^~ (^/g-cloud-7-updates/communications/?.*?) {
+    location ^~ (^/g-cloud-7-updates/communications($|/$|/.+$)) {
         proxy_intercept_errors on;
 
         proxy_pass $g7_draft_documents_s3_url$1$is_args$args;
     }
 
-    location ^~ (^/g-cloud-7/?.*?) {
+    location ^~ (^/g-cloud-7($|/$|/.+$)) {
         proxy_intercept_errors on;
 
         proxy_pass $g7_draft_documents_s3_url$1$is_args$args;

--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -14,10 +14,6 @@ server {
 
     {{ proxy_headers() }}
 
-    location /robots.txt {
-        alias {{ static_files_root }}/robots_assets.txt;
-    }
-
     # Absolute matches
     # We want to serve a blank favicon on this domain as we cannot guarantee the content it will appear above (service
     # documents, user uploaded pdfs etc.). The blank favicon stops 404s propagating past this point.
@@ -25,62 +21,79 @@ server {
         empty_gif;
     }
 
-    location / {
+    # Priority prefixes ^~ (force redirect to these exact prefixes)
+    set $g7_draft_documents_s3_url {{ g7_draft_documents_s3_url }};
+    set $frontend_url {{ frontend_url }};
+    set $static_files_root {{ static_files_root }};
+
+    location ^~ (^/g-cloud-7-updates/communications/?.*?) {
         proxy_intercept_errors on;
 
-        proxy_pass {{ documents_s3_url }};
+        proxy_pass $g7_draft_documents_s3_url$1$is_args$args;
     }
 
-    location ~ ^/[^/]+/documents/ {
+    location ^~ (^/g-cloud-7/?.*?) {
         proxy_intercept_errors on;
 
-        proxy_pass {{ documents_s3_url }};
+        proxy_pass $g7_draft_documents_s3_url$1$is_args$args;
     }
 
-    location ~ ^/[^/]+/agreements/ {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ agreements_s3_url }};
-    }
-
-    # Hack to force g7 communications to the old bucket to preserve upload times
-    location ^~ /g-cloud-7-updates/communications {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ g7_draft_documents_s3_url }};
-    }
-
-    location ~ ^/[^/]+/communications/ {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ communications_s3_url }};
-    }
-
-    location ~ ^/[^/]+/submissions/ {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ submissions_s3_url }};
-    }
-
-    location ~ ^/[^/]+/reports/ {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ reports_s3_url }};
-    }
-
-    location /g-cloud-7 {
-        proxy_intercept_errors on;
-
-        proxy_pass {{ g7_draft_documents_s3_url }};
-    }
-
-    location /404 {
+    location ^~ (^/404) {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
-        proxy_pass {{ frontend_url }};
+        proxy_pass $frontend_url$1$is_args$args;
     }
 
-    location /static {
-        proxy_pass {{ frontend_url }};
+    location ^~ (^/static/?.*?) {
+        proxy_pass $frontend_url$1$is_args$args;
+    }
+
+    location ^~ (^/robots.txt) {
+        alias $static_files_root/robots_assets.txt;
+    }
+
+    # Case sensitive regex matches ~ (these are tried in order) ([^/] means any non-slash character)
+    set $documents_s3_url {{ documents_s3_url }};
+    set $agreements_s3_url {{ agreements_s3_url }};
+    set $communications_s3_url {{ communications_s3_url }};
+    set $submissions_s3_url {{ submissions_s3_url }};
+    set $reports_s3_url {{ reports_s3_url }};
+
+    location ~ (^/[^/]+/documents/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $documents_s3_url$1$is_args$args;
+    }
+
+    location ~ (^/[^/]+/agreements/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $agreements_s3_url$1$is_args$args;
+    }
+
+    location ~ (^/[^/]+/communications/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $communications_s3_url$1$is_args$args;
+    }
+
+    location ~ (^/[^/]+/submissions/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $submissions_s3_url$1$is_args$args;
+    }
+
+    location ~ (^/[^/]+/reports/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $reports_s3_url$1$is_args$args;
+    }
+
+    # Regex catch all
+
+    location ~ (/.*) {
+        proxy_intercept_errors on;
+
+        proxy_pass $documents_s3_url$1$is_args$args;
     }
 }


### PR DESCRIPTION
We need to define our urls as variables and pass these to proxy pass to ensure the dns lookup is periodically expired.
We have seen 504 errors when the ips of our s3 buckets are changed because the DNS resolution is never expired and always points to the ip looked up when the papp is started.

> domain names statically configured in config are only looked up once on startup (or configuration reload).
> https://forum.nginx.org/read.php?2,215830,215832#msg-215832

> Setting proxy_pass to a variable forces re-resolution of the DNS names, because Nginx treats variables differently to static configuration
> https://serverfault.com/a/593003

These variables must be set _outside_ the location block:
https://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p#comment875954_593003

We also need to ensure the double slash bug doesn't return.