### PR TITLE
Include rate limit config if option set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test-nginx:
 		-e DM_COMMUNICATIONS_S3_URL=https://example.com \
 		-e DM_REPORTS_S3_URL=https://example.com \
 		-e DM_SUBMISSIONS_S3_URL=https://example.com \
+		-e DM_RATE_LIMITING_ENABLED=true \
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \
 		-d -t ${TEST_IMAGE_NAME}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The app-level nginx configurations can be found in the [Docker base repo](https:
 
 ## Variables
 
-Configuration variables, such as those controlling IP restrictions, are extracted from the environment by the
+Configuration variables, such as those controlling IP restrictions and rate limiting, are extracted from the environment by the
 `render_template.py` script before being injected into the relevant template. These DM_ environment variables are
 supplied by the manifest for the router PaaS app  - see the [DM AWS
 repo](https://github.com/alphagov/digitalmarketplace-aws/tree/master/paas). View them with `cf env router`.

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,6 +47,7 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
+{% if rate_limiting_enabled %}
     # Basic rate limiting (return 429 Too Many Requests instead of default 503)
     # Requests are by default limited to 50 requests/second, POST requests to 2 requests/second
     # Both limits also include a small burst allowance for extra requests in quick succession.
@@ -57,6 +58,7 @@ http {
     limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=50r/s;
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;
+{% endif %}
 
     # Set variable indicating to strip out trace/debug headers coming from external (non-GDS/non-dev) IPs
 

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -15,6 +15,7 @@ server {
     {% endfor %}
     deny all;
 
+{% if rate_limiting_enabled %}
     # Basic rate limiting
     limit_req zone=dm_limit burst=40 nodelay;
     limit_req zone=dm_post_limit burst=5;
@@ -27,6 +28,7 @@ server {
         proxy_method GET;
         proxy_pass http://static_429_error;
     }
+{% endif %}
 
     {{ prepare_trace_header_values() }}
 
@@ -59,6 +61,7 @@ server {
     }
 }
 
+{% if rate_limiting_enabled %}
 # Listen on port 10823 and serve a static_429_error page
 server {
     listen 10823;
@@ -66,3 +69,4 @@ server {
     root {{ static_files_root }};
     rewrite ^(.*)$ /too_many_requests.html break;
 }
+{% endif %}


### PR DESCRIPTION
Part of the work to make load testing easier (Trello: https://trello.com/c/tFiYL9vk/379-load-test-the-supplier-account-creation-journey).

Utilises the new `DM_RATE_LIMITING_ENABLED` var from the router's PaaS manifest (see https://github.com/alphagov/digitalmarketplace-aws/pull/499) to optionally include the rate limiting config.
