### PR TITLE
Set rate limit toggle to a value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test-nginx:
 		-e DM_COMMUNICATIONS_S3_URL=https://example.com \
 		-e DM_REPORTS_S3_URL=https://example.com \
 		-e DM_SUBMISSIONS_S3_URL=https://example.com \
-		-e DM_RATE_LIMITING_ENABLED=true \
+		-e DM_RATE_LIMITING_ENABLED=enabled \
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \
 		-d -t ${TEST_IMAGE_NAME}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,7 +47,7 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
-{% if rate_limiting_enabled %}
+{% if rate_limiting_enabled == "enabled" %}
     # Basic rate limiting (return 429 Too Many Requests instead of default 503)
     # Requests are by default limited to 50 requests/second, POST requests to 2 requests/second
     # Both limits also include a small burst allowance for extra requests in quick succession.

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -15,7 +15,7 @@ server {
     {% endfor %}
     deny all;
 
-{% if rate_limiting_enabled %}
+{% if rate_limiting_enabled == "enabled" %}
     # Basic rate limiting
     limit_req zone=dm_limit burst=40 nodelay;
     limit_req zone=dm_post_limit burst=5;
@@ -61,7 +61,7 @@ server {
     }
 }
 
-{% if rate_limiting_enabled %}
+{% if rate_limiting_enabled == "enabled" %}
 # Listen on port 10823 and serve a static_429_error page
 server {
     listen 10823;


### PR DESCRIPTION
Check that `DM_RATE_LIMITING_ENABLED` is set to 'enabled' or 'disabled', rather than relying on the presence or absence of the variable (which confuses Jinja) (and confuses me).