### PR TITLE
395-force-assets-favicon-mime-type-to-image-x-icon

### DIFF
--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -19,6 +19,7 @@ server {
     # documents, user uploaded pdfs etc.). The blank favicon stops 404s propagating past this point.
     location = /favicon.ico {
         empty_gif;
+        default_type image/x-icon;
     }
 
 


### PR DESCRIPTION
Force assets favicon mime type to image/x-icon

It looks like our other favicon has it's mime-type set to `image/x-icon`
We should set the assets one to this for consistency

https://trello.com/c/ZWvPcWdx/395-force-assets-favicon-mime-type-to-image-x-icon