### PR TITLE
local proxying: set a default resolver ttl of 10s

### DIFF
--- a/templates/api.j2
+++ b/templates/api.j2
@@ -3,6 +3,8 @@
 server {
     listen 80;
     server_name api.*;
+    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
+    resolver {{ resolver_ip }} valid=10s;
 
     {{ prepare_trace_header_values() }}
 
@@ -25,6 +27,8 @@ server {
 server {
     listen 80;
     server_name search-api.*;
+    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
+    resolver {{ resolver_ip }} valid=10s;
 
     {% for dev_ip in dev_user_ips.split(",") %}
     allow {{ dev_ip }};
@@ -42,6 +46,8 @@ server {
 server {
     listen 80;
     server_name antivirus-api.*;
+    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
+    resolver {{ resolver_ip }} valid=10s;
 
     {{ prepare_trace_header_values() }}
 

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -9,6 +9,8 @@ server {
     listen 80;
     server_name www.*;
     root {{ static_files_root }};
+    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
+    resolver {{ resolver_ip }} valid=10s;
 
     {% for user_ip in user_ips.split(",") %}
     allow {{ user_ip }};


### PR DESCRIPTION
https://trello.com/c/H53K45It

This is needed because internal ("private") PaaS routes are load-balanced simply on a DNS trick and our blue-green deployment procedure may make an instance disappear at any time with little notice.

While I'd love to be able to test this without merging, that slightly defeats the point because it's a problem with deployment & releasing that this is trying to fix, and we need to go through a proper release cycle to see if it works.

Note I've added this rule for connections to our frontend apps too even though we don't yet use internal routes for them - this is because I anticipate someone trying to switch them too sooner or later and I'd rather they don't have to rediscover this problem from scratch then.