### PR TITLE
Revert "local proxying: set a default resolver ttl of 10s"

### DIFF
--- a/templates/api.j2
+++ b/templates/api.j2
@@ -3,8 +3,6 @@
 server {
     listen 80;
     server_name api.*;
-    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
-    resolver {{ resolver_ip }} valid=10s;
 
     {{ prepare_trace_header_values() }}
 
@@ -27,8 +25,6 @@ server {
 server {
     listen 80;
     server_name search-api.*;
-    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
-    resolver {{ resolver_ip }} valid=10s;
 
     {% for dev_ip in dev_user_ips.split(",") %}
     allow {{ dev_ip }};
@@ -46,8 +42,6 @@ server {
 server {
     listen 80;
     server_name antivirus-api.*;
-    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
-    resolver {{ resolver_ip }} valid=10s;
 
     {{ prepare_trace_header_values() }}
 

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -9,8 +9,6 @@ server {
     listen 80;
     server_name www.*;
     root {{ static_files_root }};
-    # valid= value must be significantly less than the amount of guard time we have in our blue-green deployment process
-    resolver {{ resolver_ip }} valid=10s;
 
     {% for user_ip in user_ips.split(",") %}
     allow {{ user_ip }};


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-router#54

This change is now pointless - the approach won't work because of fun nginx things as described in https://github.com/DmitryFillo/nginx-proxy-pitfalls