### PR TITLE
logging: include requestSize

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -100,6 +100,7 @@ http {
                            ' "request": "$request", '
                            ' "status": $status, '
                            ' "size": $body_bytes_sent, '
+                           ' "requestSize": $content_length, '
                            ' "referer": "$http_referer", '
                            ' "userAgent": "$http_user_agent", '
                            ' "requestTime": $request_time, '


### PR DESCRIPTION
https://trello.com/c/bzsaiTQ1

Without this it's hard to identify when a request was "slow" simply because it was uploading a 5MB file.