### PR TITLE
requestSize logging: handle unset $content_length values 

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -92,7 +92,7 @@ http {
         "" 0;
     }
 
-    log_format access_json '{"logType": "nginx-access", '
+    log_format access_json escape=json '{"logType": "nginx-access", '
                            ' "requestId": "$http_x_b3_traceid", '
                            ' "spanId": "$http_x_b3_spanid", '
                            ' "parentSpanId": "$http_x_b3_parentspanid", '

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -87,6 +87,11 @@ http {
 
     # Logging Settings
 
+    map $content_length $content_length_or_zero {
+        default $content_length;
+        "" 0;
+    }
+
     log_format access_json '{"logType": "nginx-access", '
                            ' "requestId": "$http_x_b3_traceid", '
                            ' "spanId": "$http_x_b3_spanid", '
@@ -100,7 +105,7 @@ http {
                            ' "request": "$request", '
                            ' "status": $status, '
                            ' "size": $body_bytes_sent, '
-                           ' "requestSize": $content_length, '
+                           ' "requestSize": $content_length_or_zero, '
                            ' "referer": "$http_referer", '
                            ' "userAgent": "$http_user_agent", '
                            ' "requestTime": $request_time, '


### PR DESCRIPTION
...which is actually most requests - we can't let possibly-unset values be used unquoted in the json otherwise they'll break it.

Also enable `escape=json` option for `log_format`

https://trello.com/c/bzsaiTQ1