### PR TITLE
requestSize logging: use a regex map instead to ensure we only inject digits into the log json

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -88,8 +88,8 @@ http {
     # Logging Settings
 
     map $content_length $content_length_or_zero {
-        default $content_length;
-        "" 0;
+        default 0;
+        ~^\d+$ $content_length;
     }
 
     log_format access_json escape=json '{"logType": "nginx-access", '


### PR DESCRIPTION
https://trello.com/c/bzsaiTQ1

Sorry to keep screwing with this but we really should be a bit safer here seeing as it originates as an http header.