### PR TITLE
Serve a 404 error page when 505 error received from AWS

### DIFF
--- a/templates/assets.j2
+++ b/templates/assets.j2
@@ -3,7 +3,7 @@
 server {
     listen 80;
     server_name assets.*;
-    error_page 400 401 402 403 404 = /404;
+    error_page 400 401 402 403 404 505 = /404;
 
     {% for user_ip in user_ips.split(",") %}
     allow {{ user_ip }};


### PR DESCRIPTION
Trello: https://trello.com/c/okOq2o7m/655-505-error-for-malformed-s3-document-url

This status code returns when a malformed S3 document URL is requested (eg containing spaces, colons). We'll still get a 5xx alert but this fix should at least show a nice 404 error page to the user instead of an ugly XML error response (like the one on the ticket).

