### PR TITLE
access logs: add $upstream_connect_time, $upstream_header_time, $upstream_response_time

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -92,6 +92,7 @@ http {
         ~^\d+$ $content_length;
     }
 
+    # the various $upstream_*_times are encoded as strings as they potentially could be multiple values comma-separated
     log_format access_json escape=json '{"logType": "nginx-access", '
                            ' "requestId": "$http_x_b3_traceid", '
                            ' "spanId": "$http_x_b3_spanid", '
@@ -109,6 +110,9 @@ http {
                            ' "referer": "$http_referer", '
                            ' "userAgent": "$http_user_agent", '
                            ' "requestTime": $request_time, '
+                           ' "upstreamConnectTime": "$upstream_connect_time", '
+                           ' "upstreamHeaderTime": "$upstream_header_time", '
+                           ' "upstreamResponseTime": "$upstream_response_time", '
                            ' "httpHost": "$http_host"}';
 
     access_log /dev/stdout access_json;


### PR DESCRIPTION
Because visibility.

Note that these can have multiple comma separated values corresponding to multiple attempts.