### PR TITLE
768-p3-instability-09-05-2019-04-05am-and-06-07am

### DIFF
--- a/templates/www.j2
+++ b/templates/www.j2
@@ -41,14 +41,9 @@ server {
         deny all;
     }
 
-    location / {
-        {{ proxy_headers () }}
-        proxy_set_header Authorization "Basic {{ app_auth }}";
+    set $frontend_url {{ frontend_url }};
 
-        proxy_pass {{ frontend_url|urljoin("/") }};
-    }
-
-    location /admin {
+    location ~ (^/admin($|/$|/.+$)) {
         {% for admin_ip in admin_user_ips.split(",") %}
         allow {{ admin_ip }};
         {% endfor %}
@@ -57,7 +52,14 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass {{ frontend_url|urljoin("/admin") }};
+        proxy_pass $frontend_url$1$is_args$args;
+    }
+
+    location ~ (/.*) {
+        {{ proxy_headers () }}
+        proxy_set_header Authorization "Basic {{ app_auth }}";
+
+        proxy_pass $frontend_url$1$is_args$args;
     }
 }
 


### PR DESCRIPTION
Make frontend apps proxy_passes use regex and variable

This means that the url will be re resolved not cached for the life of the router app and that the urls will have double slashes squashed.

https://trello.com/c/HpOQ0y5V/768-p3-instability-09-05-2019-04-05am-and-06-07am


See https://github.com/alphagov/digitalmarketplace-router/pull/46 for more info