### PR TITLE
supervisord: attempt more graceful shutdown procedure through better use of signals

### DIFF
--- a/awslogs/run.sh
+++ b/awslogs/run.sh
@@ -2,4 +2,5 @@
 
 sed -i -e "s/{DM_ENVIRONMENT}/$DM_ENVIRONMENT/g" -e "s/{DM_APP_NAME}/$DM_APP_NAME/g" /etc/awslogs.conf
 
-exec /usr/local/bin/aws logs push --region eu-west-1 --config-file /etc/awslogs.conf
+# nohup because we want awslogs to keep running when everything else is stopping - see supervisord.conf
+exec nohup /usr/local/bin/aws logs push --region eu-west-1 --config-file /etc/awslogs.conf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,7 +12,10 @@ stdout_logfile_maxbytes = 50000000
 stdout_logfile_backups = 3
 stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
-stopsignal = INT
+stopsignal = STOP
+# bosh will probably kill everything after 10s - stop a second early in the hopes that the logs of our
+# last handled request make it off the machine
+stopwaitsecs = 9
 
 [program:awslogs]
 command = /awslogs.sh
@@ -23,4 +26,8 @@ stdout_logfile_maxbytes = 0
 stderr_logfile = /var/log/awslogs.log
 stderr_logfile_maxbytes = 5000000
 stderr_logfile_backups = 3
-stopsignal = INT
+# we want awslogs to keep running when everything else is shutting down so we don't miss logs
+# but supervisord has no option to disable the stopsignal, so we send it HUP but run it under nohup
+stopsignal = HUP
+# bosh will probably kill us after 10s
+stopwaitsecs = 15


### PR DESCRIPTION
https://trello.com/c/PyDaRXEj

Analogous to https://github.com/alphagov/digitalmarketplace-docker-base/pull/56/

We will never make this perfect as it's possible for an instance to have a significant number of concurrent or queued connections and only a 10s grace period given by bosh in which to clear that backlog. so make sure daemons are given graceful shutdown signals so they can get on with doing that backlog-clearing. Ensure awslogs daemon doesn't shut down at all until the last second so we have a good shot at getting logs of all handled requests.