### PR TITLE
add prometheus metric exporter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 
 !awslogs
+!nginx-prometheus-exporter.sh
 !nginx.sh
 !scripts/
 !requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV APP_DIR /app
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-                    python2.7 python-setuptools python-pip && \
+                    python2.7 python-setuptools python-pip curl && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache-dir supervisor==3.3.3 awscli awscli-cwlogs && \
     aws configure set plugins.cwlogs cwlogs && \
@@ -14,6 +14,14 @@ RUN apt-get update && \
     mkdir -p /usr/share/nginx/html && \
     mkdir -p /var/log/digitalmarketplace && \
     rm -f /etc/nginx/sites-enabled/*
+
+# TODO prefer apt-get install if nginx-prometheus-exporter is ever packaged as such
+# For now make do with binary tarball and assert its sha256
+RUN curl -SL -o nginx-prometheus-exporter.tar.gz https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v0.3.0/nginx-prometheus-exporter-0.3.0-linux-amd64.tar.gz && \
+    test $(sha256sum nginx-prometheus-exporter.tar.gz | cut -d " " -f 1) = 31de68284339041fc5539f3b5431276989bea3de3705d932e80cc9f89cc9b21a && \
+    tar -zxf nginx-prometheus-exporter.tar.gz && \
+    install nginx-prometheus-exporter /usr/local/bin/nginx-prometheus-exporter && \
+    rm -f nginx-prometheus-exporter nginx-prometheus-exporter.tar.gz
 
 COPY requirements.txt ${APP_DIR}
 RUN pip install -r ${APP_DIR}/requirements.txt
@@ -26,6 +34,8 @@ COPY awslogs/run.sh /awslogs.sh
 COPY supervisord.conf /etc/supervisord.conf
 
 COPY nginx.sh /nginx.sh
+
+COPY nginx-prometheus-exporter.sh /nginx-prometheus-exporter.sh
 
 COPY templates/ ${APP_DIR}/templates/
 COPY scripts/ ${APP_DIR}/scripts/

--- a/nginx-prometheus-exporter.sh
+++ b/nginx-prometheus-exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+exec /usr/local/bin/nginx-prometheus-exporter \
+    -web.listen-address :9113 \
+    -nginx.scrape-uri http://127.0.0.1:9112/stub-status

--- a/nginx.sh
+++ b/nginx.sh
@@ -6,9 +6,9 @@ export DM_RESOLVER_IP=$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)
 /app/scripts/render-template.py /app/templates/nginx.conf.j2 > /etc/nginx/nginx.conf
 
 if [[ $DM_MODE == 'maintenance' ]]; then
-    templates="maintenance healthcheck"
+    templates="maintenance healthcheck metrics"
 else
-    templates="api assets www healthcheck"
+    templates="api assets www healthcheck metrics"
 fi
 
 for template in $templates; do

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -31,3 +31,11 @@ stderr_logfile_backups = 3
 stopsignal = HUP
 # bosh will probably kill us after 10s
 stopwaitsecs = 15
+
+[program:nginx-prometheus-exporter]
+command = /nginx-prometheus-exporter.sh
+autostart = true
+autorestart = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+redirect_stderr = true

--- a/templates/metrics.j2
+++ b/templates/metrics.j2
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+
+    server_name *.cloudapps.digital;
+
+    # pass these requests through to the nginx-prometheus-exporter
+    location /_metrics {
+        proxy_pass http://127.0.0.1:9113/metrics;
+    }
+}
+
+# enable "stub status" endpoint for the nginx-prometheus-exporter to poll
+server {
+    listen 9112;
+
+    allow 127.0.0.1;
+    deny all;
+
+    location /stub-status {
+        stub_status;
+        access_log off;
+    }
+}


### PR DESCRIPTION
https://trello.com/c/wkDN6HHk/

This requires us to set up the "status stub", made only accessible from within the host, the `nginx-prometheus-exporter` process itself (for polling that status stub) and a `proxy_pass` rule to allow requests to `/_metrics` to be _apparently_ served by our nginx from port 80. It might seem nicer for these nginx settings to live in their own site config file, but that's tricky because we already have the healthcheck set as the default port 80 "server", so rather have to piggyback on that.

~The endpoint is set up like the healthcheck, only visible when accessed "raw" and not through one of the configured hostnames. I _think_ our "master" exporter _should_ be able to access this endpoint, but not 100% certain.~