### PR TITLE
set proxy_http_version to 1.1

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,6 +47,9 @@ http {
     # Set max request size (up to 4 files x 10Mb size limit)
     client_max_body_size 40m;
 
+    # default is 1.0, which prevents paas from doing some keepalive magick
+    proxy_http_version 1.1;
+
 {% if rate_limiting_enabled == "enabled" %}
     # Basic rate limiting (return 429 Too Many Requests instead of default 503)
     # Requests are by default limited to 50 requests/second, POST requests to 2 requests/second


### PR DESCRIPTION
https://trello.com/c/2k1WIjxX

Nginx defaults to downgrading outbound connections to http 1.0. Forcing it to use http 1.1 should allow paas to do some keepalive magick. S3, which we also proxy to, should be able to handle this too.

Tested & works on staging.