### PR TITLE
disable gzip at toplevel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     mkdir -p /etc/nginx/sites-enabled && \
     mkdir -p /usr/share/nginx/html && \
     mkdir -p /var/log/digitalmarketplace && \
-    rm -f /etc/nginx/sites-enabled/*
+    rm -f /etc/nginx/nginx.conf /etc/nginx/sites-enabled/*
 
 # TODO prefer apt-get install if nginx-prometheus-exporter is ever packaged as such
 # For now make do with binary tarball and assert its sha256

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-nginx:
 	@docker exec -d ${TEST_CONTAINER_NAME} supervisord --configuration /etc/supervisord.conf
 	@echo "## Waiting for nginx to start..."
 
-	@docker exec ${TEST_CONTAINER_NAME} sh -c "until (service nginx status >dev/null || ! nginx -t > /dev/null 2>&1); do sleep 1; done && nginx -t"
+	@docker exec ${TEST_CONTAINER_NAME} timeout 10m sh -c "until (test -s /etc/nginx/nginx.conf && (service nginx status >dev/null || ! nginx -t > /dev/null 2>&1)); do sleep 1; done && nginx -t"
 
 	@echo "## Tearing down test container and image"
 	@docker rm -f ${TEST_CONTAINER_NAME}

--- a/nginx.sh
+++ b/nginx.sh
@@ -3,8 +3,6 @@
 export DM_CLOUDFRONT_IPS=$(/app/scripts/get-cloudfront-ips.py)
 export DM_RESOLVER_IP=$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)
 
-/app/scripts/render-template.py /app/templates/nginx.conf.j2 > /etc/nginx/nginx.conf
-
 if [[ $DM_MODE == 'maintenance' ]]; then
     templates="maintenance healthcheck metrics"
 else
@@ -15,5 +13,8 @@ for template in $templates; do
     echo "Compiling $template" >&2
     /app/scripts/render-template.py /app/templates/$template.j2 > /etc/nginx/sites-enabled/$template.conf
 done
+
+# generate nginx.conf last so its existence can be used to detect readiness by e.g. tests
+/app/scripts/render-template.py /app/templates/nginx.conf.j2 > /etc/nginx/nginx.conf
 
 exec /usr/sbin/nginx

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -120,13 +120,6 @@ http {
 
     access_log /dev/stdout access_json;
 
-    # Gzip Settings
-
-    gzip on;
-    gzip_disable "msie6";
-    gzip_types text/css application/javascript;
-    gzip_proxied any;
-
     # Virtual Host Configs
 
     include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
https://trello.com/c/1ch9wfEa

There isn't a practical way of disabling gzip for `text/html` in nginx, and the sensitive nature of some of the html means we probably don't want compression there due to e.g. BREACH concerns. instead we will perform gzipping in the applications where we can have a little more control.

Tested and works on preview alongside https://github.com/alphagov/digitalmarketplace-docker-base/pull/64 but we need to wait for that to be merged and propagated to apps before merging this.