### PR TITLE
Run Travis tests with basic image instead of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
+language: minimal
 services:
   - docker
 script:


### PR DESCRIPTION
We don't have any Python tests in this repo, so for a more accurate reflection of our coverage, let's remove it from the Travis setup and use the `minimal` base image instead (which still includes `make`, `Docker` etc). Bonus: it should run quicker as well...

See https://docs.travis-ci.com/user/languages/minimal-and-generic/#minimal