### PR TITLE
Add recovery mode to enable API requests

### DIFF
--- a/nginx.sh
+++ b/nginx.sh
@@ -5,6 +5,8 @@ export DM_RESOLVER_IP=$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)
 
 if [[ $DM_MODE == 'maintenance' ]]; then
     templates="maintenance healthcheck metrics"
+elif [[ $DM_MODE == 'recovery' ]]; then
+    templates="api maintenance healthcheck metrics"
 else
     templates="api assets www healthcheck metrics"
 fi


### PR DESCRIPTION
https://trello.com/c/j1kYVu3a/1303-implement-multi-maintenance-mode

This new mode would be used following a DB restore, where we still want to block access to the FE apps, but allow Jenkins to access the APIs for jobs that reindex the restored data.

We'll need to change the corresponding Jenkins job and script to allow the new value to be set there, but if this is merged in isolation, a developer could set the `DM_MODE` environment variable using the CloudFoundry CLI.
