### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+# Dependabot config
+# https://dependabot.com/docs/config-file/
+# Checks and updates dependencies in
+# `requirements.txt`
+
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
https://trello.com/c/4ePZUeMK/1336-move-apps-tools-from-pyup-to-dependabot

Adds a Dependabot config file. This should tell Dependabot to update requirements in `requirements.txt` weekly. 

Dependabot will need to be granted access to this repo in the UI.