### PR TITLE
Use nginx.retries to ask nginx-prometheus-exporter to wait for NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && \
 
 # TODO prefer apt-get install if nginx-prometheus-exporter is ever packaged as such
 # For now make do with binary tarball and assert its sha256
-RUN curl -SL -o nginx-prometheus-exporter.tar.gz https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v0.3.0/nginx-prometheus-exporter-0.3.0-linux-amd64.tar.gz && \
-    test $(sha256sum nginx-prometheus-exporter.tar.gz | cut -d " " -f 1) = 31de68284339041fc5539f3b5431276989bea3de3705d932e80cc9f89cc9b21a && \
+RUN curl -SL -o nginx-prometheus-exporter.tar.gz https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v0.8.0/nginx-prometheus-exporter-0.8.0-linux-amd64.tar.gz && \
+    test $(sha256sum nginx-prometheus-exporter.tar.gz | cut -d " " -f 1) = fce51ce62650186f9f4cb3ff13fa4b36ffc2980058a63bccdb471c929c078e50 && \
     tar -zxf nginx-prometheus-exporter.tar.gz && \
     install nginx-prometheus-exporter /usr/local/bin/nginx-prometheus-exporter && \
     rm -f nginx-prometheus-exporter nginx-prometheus-exporter.tar.gz

--- a/nginx-prometheus-exporter.sh
+++ b/nginx-prometheus-exporter.sh
@@ -2,4 +2,5 @@
 
 exec /usr/local/bin/nginx-prometheus-exporter \
     -web.listen-address :9113 \
+    -nginx.retries 3 \
     -nginx.scrape-uri http://127.0.0.1:9112/stub-status


### PR DESCRIPTION
We've had issues where the router app metrics have not been available because the nginx-prometheus-exporter app has started before the NGINX stub_status page is available, and exited with an error.

This commit uses the command line argument `-nginx.retries int` to get nginx-prometheus-exporter to retry a couple of times before exiting with an error.

3 seems like as good a number of retries as any.