### PR TITLE
Fix robots.txt

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -22,7 +22,10 @@ services:
       - DM_COMMUNICATIONS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
       - DM_REPORTS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
       - DM_SUBMISSIONS_S3_URL=https://digitalmarketplace-dev-uploads.s3.amazonaws.com
+      - DM_RATE_LIMITING_ENABLED=disabled
     command: >
+      bash -c '
       sed -i -e "s/proxy_redirect/# proxy_redirect/g" /app/templates/_macros.j2 &&
       sed -i -e "s/www\.\*/localhost/g" /app/templates/www.j2 &&
-      supervisord --configuration /etc/supervisord.conf'
+      supervisord --configuration /etc/supervisord.conf
+      '

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -32,7 +32,7 @@ server {
 
     {{ prepare_trace_header_values() }}
 
-    location /robots.txt {
+    location = /robots.txt {
         rewrite ^(.*)$ /robots_www.txt break;
     }
 


### PR DESCRIPTION
https://trello.com/c/qmR9Qvb6/1886-robotstxt-raises-404

For some reason the prefix match wasn't working with the location block and visiting /robots.txt was resulting in a 404. This PR changes the match to be an exact one, which seems to fix ix the issue.