### PR TITLE
Add supervisord process to forward NGINX logs to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-nginx:
 		--name ${TEST_CONTAINER_NAME} \
 		-p 8080:8080 \
 		-d -t ${TEST_IMAGE_NAME}
-	@docker exec -d ${TEST_CONTAINER_NAME} supervisord --configuration /etc/supervisord.conf
+
 	@echo "## Waiting for nginx to start..."
 
 	@docker exec ${TEST_CONTAINER_NAME} timeout 10m sh -c "until (test -s /etc/nginx/nginx.conf && (service nginx status >dev/null || ! nginx -t > /dev/null 2>&1)); do sleep 1; done && nginx -t"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -32,6 +32,12 @@ stopsignal = HUP
 # bosh will probably kill us after 10s
 stopwaitsecs = 15
 
+[program:copy_logs_to_stdout]
+command=tail -f /var/log/digitalmarketplace/nginx_access.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
 [program:nginx-prometheus-exporter]
 command = /nginx-prometheus-exporter.sh
 autostart = true


### PR DESCRIPTION
We're not currently seeing all the log files in Splunk that we do on Kibana. We need have NGINX access logs in stdout of our PaaS app, so it will appear in `cf logs` and be forwarded to Splunk.

This commit copies the method used in alphagov/digitalmarketplace-docker-base#74, adding a process that continually echoes the contents of the log file to stdout. We need to keep the logfile so that awslogs can keep forwarding to CloudWatch.