### PR TITLE
Reduce rate limit for requests to 15r/s

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -58,7 +58,7 @@ http {
       default      "";
       POST         $binary_remote_addr;
     }
-    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=30r/s;
+    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=15r/s;
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;
 {% endif %}


### PR DESCRIPTION
Ticket: https://trello.com/c/XDAj8wiB/2063-large-number-of-buyer-frontend-due-to-high-traffic-on-2020-11-05

Discussed with @bjgill this seemed like a good level for now. Ideally in the future we should scale the rate limit with the number of router apps.