### PR TITLE
Enable dependabot version checking on the base nginx image

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,6 +2,7 @@
 # https://dependabot.com/docs/config-file/
 # Checks and updates dependencies in
 # `requirements.txt`
+# and the Dockerfile at the repository root
 
 version: 1
 update_configs:
@@ -12,3 +13,7 @@ update_configs:
       - match:
           dependency_type: "production"
           update_type: "all"
+
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Our router app is based off the official nginx Docker image, but we don't track the nginx version closely so we get out-of-date.

Enable dependabot checking so we can keep our router app up-to-date with its dependencies, and make sure we're aware of any vulnerabilities.

https://trello.com/c/UeAD1ZYq/1407-1-add-digitalmarketplace-router-docker-image-to-dependabot