### PR TITLE
Reduce rate limit to 5 requests/second/instance

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -52,13 +52,15 @@ http {
 
 {% if rate_limiting_enabled == "enabled" %}
     # Basic rate limiting (return 429 Too Many Requests instead of default 503)
-    # Requests are by default limited to 30 requests/second, POST requests to 2 requests/second
     # None of these default limits include a burst. A burst is included in the www.j2 template
     map $request_method $post_remote_addr {
       default      "";
       POST         $binary_remote_addr;
     }
-    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=15r/s;
+    # Requests are by default limited to 5 requests/second/router instance, POST requests to 2
+    # requests/second/router instance.
+    # As of February 2021, there are normally 6 router instances.
+    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=5r/s;
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;
 {% endif %}


### PR DESCRIPTION
https://trello.com/c/xoQsBBAd

We have a scraper that hits us with a very large amount of traffic in a short space of time every day. Buyer-frontend is unable to cope, and gets terminated. See the linked Trello ticket for more detailed information.

The scraper is currently just under our rate limit. So try reducing the rate limit. Hopefully, they are nice and will start limiting their request rate to one we can handle. If not, we may need to try more extreme measures.

I propose lowering the rate limit to 5 requests/second/instance (30 requests/second overall). We should review our logs after a week to see what impact this had on users and on the scraper.