### PR TITLE
Add Content-Security-Policy header

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google-analytics.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
 
     # Basic Settings
     sendfile on;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com;" always;
 
     # Basic Settings
     sendfile on;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -32,6 +32,7 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google-analytics.com;" always;
 
     # Basic Settings
     sendfile on;


### PR DESCRIPTION
The recent ITHC identified that we were missing some HTTP response headers that they would recommend including as best practice to prevent the risk of cross site scripting and other code execution attacks

`Content-Security-Policy` aims to mitigate XSS attacks by allowing the server administrator to specify domains the browser is allowed to load and execute resources from[[1]]. 

This policy allows:
1. All resources from the domain the page is served on
2. Scripts from our domain, inline scripts and from Google Analytics
3. Images from our domain and inline SVGs using a `data:` url
4. Scripts to load URLs on our domain and for Google Analytics

https://trello.com/c/q6d3d6vP/884-3-address-ithc-issue-612-missing-http-security-headers

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP