### PR TITLE
Opt out of Google Federated Learning of Cohorts computation

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -33,6 +33,7 @@ http {
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com;" always;
+    add_header Permissions-Policy "interest-cohort=()" always;
 
     # Basic Settings
     sendfile on;


### PR DESCRIPTION
In a blog post **'Privacy, sustainability and the importance of “and”'**[[1]], Google announced their new approach to audience-led display ads in the absence of third party cookies.

The blog post and the web.dev post[[2]] have more details, but in summary Google will use aggregated browsing history data to generate cohorts of people with similar browsing behaviour. Browsers then use this cohort model and apply it to the local browsing history to determine which cohort the user most likely fits into. This is designed to preserve the user's privacy because their browsing history isn't sent off to another company to be analysed - the cohort assignment happens on their machine.

However, there are still privacy concerns[[3]] about how the cohort model is trained and how Google will exclude sensitive sites and data from the cohorts. Also, we have already made the decision to switch off the parts of Google Analytics that uses our site data for use in building advertising audiences, so we should opt out of this use as well.

The proposed implementation[[4]] offers a way for websites and services to control what information they pass back to Google via the existing `Permissions-Policy` header[[5]]. Setting

```
Permissions-Policy: interest-cohort=()
```
on every response opts out of all FLoC cohort calculation.

[1]: https://blog.google/products/chrome/privacy-sustainability-and-the-importance-of-and
[2]: https://web.dev/digging-into-the-privacy-sandbox/#select-ads
[3]: https://twitter.com/lukOlejnik/status/1377274245684858885
[4]: https://github.com/WICG/floc
[5]: https://www.w3.org/TR/permissions-policy-1/