### PR TITLE
Reduce request rate limits and allowed burst

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -59,10 +59,10 @@ http {
       default      "";
       POST         $binary_remote_addr;
     }
-    # Requests are by default limited to 5 requests/second/router instance, POST requests to 2
+    # Requests are by default limited to 3 requests/second/router instance, POST requests to 2
     # requests/second/router instance.
     # As of February 2021, there are normally 6 router instances.
-    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=5r/s;
+    limit_req_zone $binary_remote_addr zone=dm_limit:10m rate=3r/s;
     limit_req_zone $post_remote_addr zone=dm_post_limit:10m rate=2r/s;
     limit_req_status 429;
 {% endif %}

--- a/templates/www.j2
+++ b/templates/www.j2
@@ -17,7 +17,7 @@ server {
 
 {% if rate_limiting_enabled == "enabled" %}
     # Basic rate limiting
-    limit_req zone=dm_limit burst=40;
+    limit_req zone=dm_limit burst=20;
     limit_req zone=dm_post_limit burst=5;
 
     error_page 429 @too_many_requests;


### PR DESCRIPTION
Trello: https://trello.com/c/wW4w1XQZ

We've got a scraper who attempts to scrape 1500-2000 pages in the space of 2 minutes on a regular basis. We're almost able to cope with this, but are still getting the odd 502 response that suggests that the DMp is unable to cope with this level of traffic 100% reliably.

So halve the permitted rate limit and also the allowed burst. The DMp should easily be able to handle the scraper's current level of traffic given this rate limit. We'll need to monitor to check whether this affects any other users.

We also need to take other steps to make the DMp more able to cope with this sort of traffic. Reducing the rate limit should buy us the time to make those improvements.

**If you are the scraper in question**: please [contact us](https://www.digitalmarketplace.service.gov.uk/help) so we can help you meet your needs without overwhelming us.