### PR TITLE
Add assets subdomain to CSP

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com; object-src 'self' https://assets.digitalmarketplace.service.gov.uk;" always;
     add_header Permissions-Policy "interest-cohort=()" always;
 
     # Basic Settings


### PR DESCRIPTION
Currently, admins are unable to view framework agreements. We think this is because the Content Security Policy does not allow our assets subdomain, which we embed to display the agreements. This was introduced in https://github.com/alphagov/digitalmarketplace-router/pull/106.

So add our assets subdomain to our CSP.

I'll merge this to Preview to test whether it fixes our problems.