### PR TITLE
Add assets subdomain to CSP for Chrome

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com; object-src 'self' https://assets.digitalmarketplace.service.gov.uk;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com; object-src 'self' https://assets.digitalmarketplace.service.gov.uk; frame-src 'self' https://assets.digitalmarketplace.service.gov.uk;" always;
     add_header Permissions-Policy "interest-cohort=()" always;
 
     # Basic Settings


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4533739

We can't currently embed PDF from our assets domain on Chrome. This should work because we've set object-src, which controls embedding (https://github.com/alphagov/digitalmarketplace-router/pull/110).

However, Chrome seems to have a bug that makes it look at frame-src instead (https://stackoverflow.com/questions/57826510/chrome-shows-frame-src-error-even-if-using-object). So we need to provide frame-src.