### PR TITLE
Add supervisor_stdout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 !static_files
 !supervisord.conf
 !templates
+!supervisor_stdout.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     python3.7 python3-setuptools python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --no-cache-dir supervisor==4.2.1 awscli awscli-cwlogs && \
+    pip3 install --no-cache-dir supervisor==4.2.2 awscli awscli-cwlogs && \
     aws configure set plugins.cwlogs cwlogs && \
     mkdir -p ${APP_DIR} && \
     mkdir -p /etc/nginx/sites-available && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY static_files/* /usr/share/nginx/html/
 
 COPY awslogs/awslogs.conf /etc/awslogs.conf
 COPY awslogs/run.sh /awslogs.sh
+COPY supervisor_stdout.py /usr/local/lib/python3.6/site-packages
+COPY supervisor_stdout.py /usr/local/bin/supervisor_stdout
 
 COPY supervisord.conf /etc/supervisord.conf
 

--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -1,0 +1,58 @@
+#!/usr/local/bin/python3.6
+
+"""A simple supervisord event listener to relay process output to supervisor's stdout
+Copied from https://github.com/coderanger/supervisor-stdout and modified to remove the prefix
+Copyright (c) 2012, Noah Kantrowitz
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Noah Kantrowitz nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
+  specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Noah Kantrowitz BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+from __future__ import print_function
+import sys
+
+
+def write_stdout(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+
+def main():
+    while 1:
+        write_stdout('READY\n')  # transition from ACKNOWLEDGED to READY
+        line = sys.stdin.readline()   # read header line from stdin
+        headers = dict([x.split(':') for x in line.split()])
+        data = sys.stdin.read(int(headers['len']))  # read the event payload
+        write_stdout('RESULT %s\n%s' % (len(data.encode("utf-8")), data))  # transition from READY to ACKNOWLEDGED
+
+
+def event_handler(event, response):
+    response = response.decode()
+    _, data = response.split('\n', 1)
+    print(data.strip())
+
+
+if __name__ == '__main__':
+    main()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,6 +12,8 @@ stdout_logfile_maxbytes = 50000000
 stdout_logfile_backups = 3
 stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
+stdout_events_enabled = true
+stderr_events_enabled = true
 stopsignal = STOP
 # bosh will probably kill everything after 10s - stop a second early in the hopes that the logs of our
 # last handled request make it off the machine
@@ -32,8 +34,8 @@ stopsignal = HUP
 # bosh will probably kill us after 10s
 stopwaitsecs = 15
 
-[program:copy_logs_to_stdout]
-command=tail -f /var/log/digitalmarketplace/nginx_access.log
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-redirect_stderr=true
+[event_handler:copy_logs_to_stdout]
+command = supervisor_stdout
+buffersize = 1000
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
Use a fork of https://github.com/coderanger/supervisor-stdout to forward logs from application to stdout.

The previous solution was not resilient to log rotation, so we would lose logs after the app had been running for a while. This new solution should hopefully not have the same issue.

Very similar to https://github.com/alphagov/digitalmarketplace-docker-base/pull/80

https://trello.com/c/QawDH4Jz/2207-what-happened-to-the-nginx-access-logs